### PR TITLE
fix two crash add Victory screen and lock tactical

### DIFF
--- a/vscripts/gamemodes/custom_tdm/sh_gamemode_custom_tdm.nut
+++ b/vscripts/gamemodes/custom_tdm/sh_gamemode_custom_tdm.nut
@@ -56,7 +56,7 @@ struct {
 void function Sh_CustomTDM_Init() 
 {
 
-
+Remote_RegisterClientFunction("ServerCallback_TDM_DoVictoryAnnounce", "int", 0, 255)
     // Map locations
 
     switch(GetMapName())


### PR DESCRIPTION
1.fix the server crash problem"GetTeam on in valid entity"
2.fix the problem when use tgive to get tactical the tactical cooldown will reset(it will count from 0 now),add a new function to soft lock the tactical（we //it，if somebody want to use to soft lock the tactical）
3.add the Victory screen.Winner team will show"victory screen”，and the other will show "game over", if draw ,two team both show"game over"
code by Neko and Black201